### PR TITLE
Remove @types/mocha as a dev dependency

### DIFF
--- a/packages/fmg-core/package.json
+++ b/packages/fmg-core/package.json
@@ -19,11 +19,11 @@
   "author": "Tom Close",
   "license": "MIT",
   "dependencies": {
-    "@types/mocha": "^5.2.5",
     "sha3": "^1.2.2",
     "web3-utils": "^1.0.0-beta.30"
   },
   "devDependencies": {
+    "@types/mocha": "^5.2.5",
     "@types/node": "^10.5.1",
     "@types/web3": "^1.0.0-beta.30",
     "copyfiles": "^2.0.0",


### PR DESCRIPTION
If it's a dev dependency it seems to conflict with other testing packages as it's imported (e.g. `yarn` also defines `describe` as a global). With the dev dependency I was getting the following error in `rps-poc`:
```
Subsequent variable declarations must have the same type.  'beforeEach' must be of type 'Lifecycle', but here has type 'HookFunction'.
```