### PR TITLE
Add conclude event and allow multiple calls to conclude

### DIFF
--- a/packages/fmg-simple-adjudicator/contracts/SimpleAdjudicator.sol
+++ b/packages/fmg-simple-adjudicator/contracts/SimpleAdjudicator.sol
@@ -232,7 +232,6 @@ contract SimpleAdjudicator {
         bytes32 s
     )
       public
-      onlyWhenGameTerminated
     {
         return _withdraw(participant, destination, _channelId,v,r,s);
     }
@@ -246,6 +245,7 @@ contract SimpleAdjudicator {
         bytes32 s
     )
       internal
+      onlyWhenGameTerminated
     {
 
         // check that the participant has signed off on the destination

--- a/packages/fmg-simple-adjudicator/contracts/SimpleAdjudicator.sol
+++ b/packages/fmg-simple-adjudicator/contracts/SimpleAdjudicator.sol
@@ -63,7 +63,7 @@ contract SimpleAdjudicator {
 
         createChallenge(uint32(now + challengeDuration), _toState);
     }
-
+    event GameConcluded();
     function conclude(
         bytes _penultimateState,
         bytes _ultimateState,
@@ -72,21 +72,24 @@ contract SimpleAdjudicator {
         bytes32[] _s
     )
       external
-      onlyWhenGameOngoing
     {
-        // channelId must match the game supported by the channel
-        require(_penultimateState.channelId() == fundedChannelId);
+        // Only attempt to conclude the game if it's not already concluded
+        if (!expiredChallengePresent()){
+            // channelId must match the game supported by the channel
+            require(_penultimateState.channelId() == fundedChannelId);
 
-        // passing _v, _r, _s directly to validConclusionProof gives a "Stack too deep" error
-        uint8[] memory v = _v;
-        bytes32[] memory r = _r;
-        bytes32[] memory s = _s;
+            // passing _v, _r, _s directly to validConclusionProof gives a "Stack too deep" error
+            uint8[] memory v = _v;
+            bytes32[] memory r = _r;
+            bytes32[] memory s = _s;
 
-        // must be a valid conclusion proof according to framework rules
-        require(Rules.validConclusionProof(_penultimateState, _ultimateState, v, r, s));
+            // must be a valid conclusion proof according to framework rules
+            require(Rules.validConclusionProof(_penultimateState, _ultimateState, v, r, s));
 
-        // Create an expired challenge, (possibly) overwriting any existing challenge
-        createChallenge(uint32(now), _ultimateState);
+            // Create an expired challenge, (possibly) overwriting any existing challenge
+            createChallenge(uint32(now), _ultimateState);
+            emit GameConcluded();
+        }
     }
 
     event Refuted(bytes refutation);

--- a/packages/fmg-simple-adjudicator/contracts/SimpleAdjudicator.sol
+++ b/packages/fmg-simple-adjudicator/contracts/SimpleAdjudicator.sol
@@ -83,6 +83,14 @@ contract SimpleAdjudicator {
                 _s
             );
         }
+
+        require(
+            // You can't compare calldata bytes (eg _ultimateState) with
+            // storage bytes (eg. currentChallenge.state)
+            keccak256(_ultimateState) == keccak256(currentChallenge.state),
+            "Game already concluded with a different conclusion proof"
+        );
+
         _withdraw(participant, destination,_channelId,_v[2],_r[2],_s[2]);
 
     }

--- a/packages/fmg-simple-adjudicator/test/simple-adjudicator.js
+++ b/packages/fmg-simple-adjudicator/test/simple-adjudicator.js
@@ -155,6 +155,19 @@ contract('SimpleAdjudicator', (accounts) => {
     })
   });
 
+  it("can only be concluded once", async () => {
+    aliceState = state0;
+    bobState = state1;
+     aliceState.stateType = State.StateType.Conclude;
+    bobState.stateType = State.StateType.Conclude;
+     const { r: r0, s: s0, v: v0 } = sign(aliceState.toHex(), alice.privateKey);
+    const { r: r1, s: s1, v: v1 } = sign(bobState.toHex(), bob.privateKey);
+     await simpleAdj.conclude(aliceState.toHex(), bobState.toHex(), [v0, v1], [r0, r1], [s0, s1] );
+    assertRevert(
+      simpleAdj.conclude(aliceState.toHex(), bobState.toHex(), [v0, v1], [r0, r1], [s0, s1])
+    );
+  });
+  
   describe("withdrawals", () => {
     let aliceStart, bobStart;
     async function withdrawHelper(account, destination) {

--- a/packages/fmg-simple-adjudicator/test/simple-adjudicator.js
+++ b/packages/fmg-simple-adjudicator/test/simple-adjudicator.js
@@ -155,22 +155,6 @@ contract('SimpleAdjudicator', (accounts) => {
     })
   });
 
-  it("can only be concluded once", async () => {
-    aliceState = state0;
-    bobState = state1;
-
-    aliceState.stateType = State.StateType.Conclude;
-    bobState.stateType = State.StateType.Conclude;
-
-    const { r: r0, s: s0, v: v0 } = sign(aliceState.toHex(), alice.privateKey);
-    const { r: r1, s: s1, v: v1 } = sign(bobState.toHex(), bob.privateKey);
-
-    await simpleAdj.conclude(aliceState.toHex(), bobState.toHex(), [v0, v1], [r0, r1], [s0, s1] );
-    assertRevert(
-      simpleAdj.conclude(aliceState.toHex(), bobState.toHex(), [v0, v1], [r0, r1], [s0, s1])
-    );
-  });
-
   describe("withdrawals", () => {
     let aliceStart, bobStart;
     async function withdrawHelper(account, destination) {


### PR DESCRIPTION
I've added a simple Conclude Event that we can listen for in the app.

I've also changed Conclude so that if it's called after the game is expired nothing happens. I'm not sure if this is the best approach but it was a quick way for now to work on the conclusion workflow. Perhaps this should be handled in a `ConcludeAndWithdraw` method?