### PR TITLE
Improve ethers compatibility

### DIFF
--- a/packages/fmg-core/package-lock.json
+++ b/packages/fmg-core/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "fmg-core",
-  "version": "0.3.0",
+  "version": "0.3.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/fmg-core/src/state.ts
+++ b/packages/fmg-core/src/state.ts
@@ -1,6 +1,7 @@
 import { Channel } from './channel';
 import BN from 'bn.js';
 import abi from 'web3-eth-abi';
+import { utils } from 'ethers';
 
 const SolidityStateType = {
   "StateStruct": {
@@ -71,6 +72,20 @@ class State {
       this.resolution.map(String),
       this.gameAttributes,
     ];
+  }
+
+  get asEthersObject() {
+    return { 
+      channelType: this.channel.channelType,
+      channelNonce: utils.bigNumberify(this.channel.channelNonce),
+      numberOfParticipants: utils.bigNumberify(this.numberOfParticipants),
+      participants: this.channel.participants,
+      stateType: this.stateType,
+      turnNum: utils.bigNumberify(this.turnNum),
+      stateCount: utils.bigNumberify(this.stateCount),
+      resolution: this.resolution.map(x => utils.bigNumberify(String(x))),
+      gameAttributes: this.gameAttributes,
+  };
   }
 }
 

--- a/packages/fmg-core/src/test/framework/transitions.test.ts
+++ b/packages/fmg-core/src/test/framework/transitions.test.ts
@@ -1,4 +1,4 @@
-import { ethers, ContractFactory, Wallet } from 'ethers';
+import { ethers, ContractFactory } from 'ethers';
 import linker from 'solc/linker';
 
 import expectRevert from '../helpers/expect-revert';
@@ -15,8 +15,7 @@ import CountingStateArtifact from '../../../build/contracts/CountingState.json';
 import CountingGameArtifact from '../../../build/contracts/CountingGame.json';
 
 const provider = new ethers.providers.JsonRpcProvider('http://localhost:8545');
-const privateKey = '0xf2f48ee19680706196e2e339e5da3491186e0c4c5030670656b0e0164837257d';
-const wallet = new Wallet(privateKey, provider);
+const signer = provider.getSigner();
 
 const TURN_NUM_MUST_INCREMENT = "turnNum must increase by 1";
 const CHANNEL_ID_MUST_MATCH = "channelId must match";
@@ -59,7 +58,7 @@ describe('Rules', () => {
     CountingGameArtifact.bytecode = linker.linkBytecode(CountingGameArtifact.bytecode, {
       CountingState: CountingStateArtifact.networks[networkId].address,
     });
-    const gameContract = await ContractFactory.fromSolidity(CountingGameArtifact, wallet).attach(
+    const gameContract = await ContractFactory.fromSolidity(CountingGameArtifact, signer).attach(
       CountingGameArtifact.networks[networkId].address,
     );
 
@@ -71,7 +70,7 @@ describe('Rules', () => {
 
     TestRulesArtifact.bytecode = linker.linkBytecode(TestRulesArtifact.bytecode, { "State": StateArtifact.networks[networkId].address });
     TestRulesArtifact.bytecode = linker.linkBytecode(TestRulesArtifact.bytecode, { "Rules": RulesArtifact.networks[networkId].address });
-    testFramework = await ContractFactory.fromSolidity(TestRulesArtifact, wallet).deploy();
+    testFramework = await ContractFactory.fromSolidity(TestRulesArtifact, signer).deploy();
     // Contract setup --------------------------------------------------------------------------
 
     channel = new Channel(gameContract.address, 0, participants);

--- a/packages/fmg-core/src/test/state.test.ts
+++ b/packages/fmg-core/src/test/state.test.ts
@@ -56,27 +56,27 @@ describe('State', () => {
 
   it('identifies stateTypes', async () => {
     state.stateType = State.StateType.PreFundSetup;
-    expect(await testStateLib.isPreFundSetup(state.args)).toBe(true);
+    expect(await testStateLib.isPreFundSetup(state.asEthersObject)).toBe(true);
 
     state.stateType = State.StateType.PostFundSetup;
-    expect(await testStateLib.isPostFundSetup(state.args)).toBe(true);
+    expect(await testStateLib.isPostFundSetup(state.asEthersObject)).toBe(true);
 
     state.stateType = State.StateType.Game;
-    expect(await testStateLib.isGame(state.args)).toBe(true);
+    expect(await testStateLib.isGame(state.asEthersObject)).toBe(true);
 
     state.stateType = State.StateType.Conclude;
-    expect(await testStateLib.isConclude(state.args)).toBe(true);
+    expect(await testStateLib.isConclude(state.asEthersObject)).toBe(true);
   });
 
   it('identifies the mover based on the turnNum', async () => {
-    const mover = await testStateLib.mover(state.args);
+    const mover = await testStateLib.mover(state.asEthersObject);
     // our state nonce is 15, which is odd, so it should be participant[1]
     expect(mover).toEqual(participants[1]);
   });
 
   it('can calculate the channelId', async () => {
-    const chainId = await testStateLib.channelId(state.args);
-    const localId = channel.id;
+    const chainId: string = await testStateLib.channelId(state.asEthersObject);
+    const localId: string = channel.id;
 
     expect(chainId).toEqual(localId);
   });
@@ -85,13 +85,13 @@ describe('State', () => {
     // needs to be signed by 1 as it's their move
     const { r, s, v } = sign(state.toHex(), participantB.privateKey);
 
-    expect(await testStateLib.requireSignature(state.args, v, r, s)).toBeTruthy();
+    expect(await testStateLib.requireSignature(state.asEthersObject, v, r, s)).toBeTruthy();
   });
 
   it('will revert if the wrong party signed', async () => {
     // needs to be signed by 1 as it's their move
     const { v, r, s } = sign(state.toHex(), participantA.privateKey);
-    expectRevert(testStateLib.requireSignature(state.args, v, r, s));
+    expectRevert(testStateLib.requireSignature(state.asEthersObject, v, r, s));
   });
 
   it('can check if the state is fully signed', async () => {
@@ -99,7 +99,7 @@ describe('State', () => {
     const { r: r1, s: s1, v: v1 } = sign(state.toHex(), participantB.privateKey);
 
     expect(
-      await testStateLib.requireFullySigned(state.args, [v0, v1], [r0, r1], [s0, s1]),
+      await testStateLib.requireFullySigned(state.asEthersObject, [v0, v1], [r0, r1], [s0, s1]),
     ).toBeTruthy();
   });
 
@@ -107,6 +107,6 @@ describe('State', () => {
     const state1 = CountingGame.preFundSetupState({ channel, resolution, turnNum, gameCounter: 0 });
     const state2 = CountingGame.preFundSetupState({ channel, resolution, turnNum, gameCounter: 1 });
 
-    await expectRevert(stateLib.gameAttributesEqual(state1.args, state2.args));
+    await expectRevert(stateLib.gameAttributesEqual(state1.asEthersObject, state2.asEthersObject));
   });
 });

--- a/packages/fmg-core/src/test/state.test.ts
+++ b/packages/fmg-core/src/test/state.test.ts
@@ -6,15 +6,14 @@ import { CountingGame } from '../test-game/counting-game';
 import { sign } from '../utils';
 import linker from 'solc/linker';
 
-import { ethers, ContractFactory, Wallet, Contract } from 'ethers';
+import { ethers, ContractFactory, Wallet } from 'ethers';
 
 // @ts-ignore
 import StateArtifact from '../../build/contracts/State.json';
 import TestStateArtifact from '../../build/contracts/TestState.json';
 
 const provider = new ethers.providers.JsonRpcProvider('http://localhost:8545');
-const privateKey = '0xf2f48ee19680706196e2e339e5da3491186e0c4c5030670656b0e0164837257d';
-const wallet = new Wallet(privateKey, provider);
+const signer = provider.getSigner();
 
 describe('State', () => {
 
@@ -47,11 +46,11 @@ describe('State', () => {
   beforeEach(async () => {
     const networkId = (await provider.getNetwork()).chainId;
 
-    const factory = ContractFactory.fromSolidity(StateArtifact, wallet);
+    const factory = ContractFactory.fromSolidity(StateArtifact, signer);
     stateLib = await factory.attach(StateArtifact.networks[networkId].address);
 
     TestStateArtifact.bytecode = linker.linkBytecode(TestStateArtifact.bytecode, { "State": StateArtifact.networks[networkId].address });
-    testStateLib = await ContractFactory.fromSolidity(TestStateArtifact, wallet).deploy();
+    testStateLib = await ContractFactory.fromSolidity(TestStateArtifact, signer).deploy();
   });
 
   it('identifies stateTypes', async () => {

--- a/packages/fmg-core/src/test/test-game/counting-game.test.ts
+++ b/packages/fmg-core/src/test/test-game/counting-game.test.ts
@@ -12,8 +12,7 @@ import CountingStateArtifact from '../../../build/contracts/CountingState.json';
 import CountingGameArtifact from '../../../build/contracts/CountingGame.json';
 
 const provider = new ethers.providers.JsonRpcProvider('http://localhost:8545');
-const privateKey = '0xf2f48ee19680706196e2e339e5da3491186e0c4c5030670656b0e0164837257d';
-const wallet = new Wallet(privateKey, provider);
+const signer = provider.getSigner();
 
 describe('CountingGame', () => {
   let game;
@@ -31,7 +30,7 @@ describe('CountingGame', () => {
     CountingGameArtifact.bytecode = linker.linkBytecode(CountingGameArtifact.bytecode, {
       CountingState: CountingStateArtifact.networks[networkId].address,
     });
-    game = await ContractFactory.fromSolidity(CountingGameArtifact, wallet).attach(
+    game = await ContractFactory.fromSolidity(CountingGameArtifact, signer).attach(
       CountingGameArtifact.networks[networkId].address,
     );
     // Contract setup --------------------------------------------------------------------------

--- a/packages/fmg-core/src/test/test-game/counting-state.test.ts
+++ b/packages/fmg-core/src/test/test-game/counting-state.test.ts
@@ -2,7 +2,7 @@ import { CountingGame } from '../../test-game/counting-game';
 import linker from 'solc/linker';
 
 import { Channel } from '../../';
-import { ethers, Wallet, ContractFactory, utils } from 'ethers';
+import { ethers, ContractFactory, utils } from 'ethers';
 
 import StateArtifact from '../../../build/contracts/State.json';
 
@@ -10,8 +10,7 @@ import CountingStateArtifact from '../../../build/contracts/CountingState.json';
 import TestCountingStateArtifact from '../../../build/contracts/TestCountingState.json';
 
 const provider = new ethers.providers.JsonRpcProvider('http://localhost:8545');
-const privateKey = '0xf2f48ee19680706196e2e339e5da3491186e0c4c5030670656b0e0164837257d';
-const wallet = new Wallet(privateKey, provider);
+const signer = provider.getSigner();
 
 describe('CountingState', () => {
   let testCountingState;
@@ -32,7 +31,7 @@ describe('CountingState', () => {
         State: StateArtifact.networks[networkId].address,
     });
 
-    testCountingState = await ContractFactory.fromSolidity(TestCountingStateArtifact, wallet).deploy();
+    testCountingState = await ContractFactory.fromSolidity(TestCountingStateArtifact, signer).deploy();
 
     // Contract setup --------------------------------------------------------------------------
 


### PR DESCRIPTION
Using the [provider's default signer](https://github.com/ethers-io/ethers.js/issues/363#issuecomment-444296712) `provider.getSigner(0)` is meant to fix the nonce-management issue that causes the `the tx doesn't have the correct nonce. account has nonce of: 95 tx has nonce of: 94` error.

Sadly it [still doesn't](https://github.com/ethers-io/ethers.js/issues/363#issuecomment-445401082) prevent flickering tests, for which we might have to wait for a fix, or switch to web3 contracts.