### PR TITLE
Pinned web3 versions

### DIFF
--- a/packages/fmg-core/package.json
+++ b/packages/fmg-core/package.json
@@ -21,8 +21,10 @@
     "bn.js": "^4.11.8",
     "ethers": "^4.0.26",
     "sha3": "^1.2.2",
-    "web3": "^1.0.0-beta.36",
-    "web3-utils": "^1.0.0-beta.36",
+    "web3": "1.0.0-beta.37",
+    "web3-utils": "1.0.0-beta.37",
+    "web3-eth-accounts": "1.0.0-beta.37",
+    "web3-eth-abi": "1.0.0-beta.37",
     "websocket": "^1.0.28"
   },
   "devDependencies": {

--- a/packages/fmg-core/src/utils.ts
+++ b/packages/fmg-core/src/utils.ts
@@ -1,6 +1,8 @@
-import Web3 from 'web3';
 import { Signature, Uint256 } from './types';
 import { bigNumberify } from 'ethers/utils';
+
+import Web3Accounts from 'web3-eth-accounts';
+import web3Utils from 'web3-utils';
 
 export function toUint256(num: number): Uint256 {
   return bigNumberify(num).toHexString();
@@ -29,21 +31,19 @@ export class SolidityParameter {
 export type SignableData = string | SolidityParameter | SolidityParameter[];
 
 export function sign(data: SignableData, privateKey): Signature {
-  const localWeb3 = new Web3('');
-  return localWeb3.eth.accounts.sign(hash(data), privateKey);
+  return (new Web3Accounts('')).sign(hash(data), privateKey);
 }
 
 export function recover(data: SignableData, signature: Signature): string {
-  const web3 = new Web3('');
   const { v, r, s } = signature;
-  return web3.eth.accounts.recover(hash(data), v, r, s);
+  return (new Web3Accounts('')).recover(hash(data), v, r, s);
 }
 
 function hash(data: SignableData): string {
   if (typeof data === 'string' || data instanceof SolidityParameter) {
-    return Web3.utils.soliditySha3(data);
+    return web3Utils.soliditySha3(data);
   } else {
-    return Web3.utils.soliditySha3(...data);
+    return web3Utils.soliditySha3(...data);
   }
 }
 

--- a/packages/fmg-nitro-adjudicator/package.json
+++ b/packages/fmg-nitro-adjudicator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fmg-nitro-adjudicator",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "main": "./lib/index.js",
   "repository": "https://github.com/magmo/nitro-adjudicator.git",
   "author": "Andrew Stewart <andrew.gord.stewart@gmail.com>",
@@ -12,9 +12,9 @@
     "build": "tslint --project . && tsc"
   },
   "dependencies": {
-    "web3": "^1.0.0-beta.37",
     "ethers": "^4.0.26",
-    "fmg-core": "^0.5.4"
+    "fmg-core": "^0.5.4",
+    "web3": "^1.0.0-beta.37"
   },
   "devDependencies": {
     "@types/jest": "^23.3.10",

--- a/packages/fmg-nitro-adjudicator/package.json
+++ b/packages/fmg-nitro-adjudicator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fmg-nitro-adjudicator",
-  "version": "0.0.9",
+  "version": "0.0.7",
   "main": "./lib/index.js",
   "repository": "https://github.com/magmo/nitro-adjudicator.git",
   "author": "Andrew Stewart <andrew.gord.stewart@gmail.com>",
@@ -12,9 +12,9 @@
     "build": "tslint --project . && tsc"
   },
   "dependencies": {
+    "web3": "1.0.0-beta.37",
     "ethers": "^4.0.26",
-    "fmg-core": "^0.5.4",
-    "web3": "^1.0.0-beta.37"
+    "fmg-core": "^0.5.4"
   },
   "devDependencies": {
     "@types/jest": "^23.3.10",

--- a/packages/fmg-nitro-adjudicator/package.json
+++ b/packages/fmg-nitro-adjudicator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fmg-nitro-adjudicator",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "main": "./lib/index.js",
   "repository": "https://github.com/magmo/nitro-adjudicator.git",
   "author": "Andrew Stewart <andrew.gord.stewart@gmail.com>",


### PR DESCRIPTION
Web3 introduces breaking changes in their beta releases, which means
that without pinning this version, we can break our code by running
`yarn upgrade`.

This pins to a specific version of web3.