### PR TITLE
Fix Transfer/Overlap issues

### DIFF
--- a/packages/fmg-nitro-adjudicator/contracts/NitroAdjudicator.sol
+++ b/packages/fmg-nitro-adjudicator/contracts/NitroAdjudicator.sol
@@ -173,8 +173,11 @@ contract NitroAdjudicator {
                 // array.
                 result =result.add(min(outcome.allocation[i], funding));
             }
-
-            funding = funding.sub(outcome.allocation[i]);
+            if (funding > outcome.allocation[i]){
+                funding = funding.sub(outcome.allocation[i]);
+            }else{
+                funding = 0;
+            }
         }
 
         return result;

--- a/packages/fmg-nitro-adjudicator/contracts/NitroAdjudicator.sol
+++ b/packages/fmg-nitro-adjudicator/contracts/NitroAdjudicator.sol
@@ -90,7 +90,7 @@ contract NitroAdjudicator {
             "Transfer: outcome must be present"
         );
 
-        uint channelAffordsForDestination = overlap(destination, outcomes[channel], holdings[channel]);
+        uint channelAffordsForDestination = affords(destination, outcomes[channel], holdings[channel]);
 
         require(
             amount <= channelAffordsForDestination,
@@ -100,7 +100,7 @@ contract NitroAdjudicator {
         holdings[destination] = holdings[destination] + amount;
         holdings[channel] = holdings[channel] - amount;
 
-        outcomes[channel] = remove(outcomes[channel], destination, amount);
+        outcomes[channel] = reduce(outcomes[channel], destination, amount);
     }
 
     function claim(address guarantor, address recipient, uint amount) public {
@@ -116,8 +116,8 @@ contract NitroAdjudicator {
 
         uint funding = holdings[guarantor];
         Outcome memory reprioritizedOutcome = reprioritize(outcomes[guarantee.guaranteedChannel], guarantee);
-        if (overlap(recipient, reprioritizedOutcome, funding) >= amount) {
-            outcomes[guarantee.guaranteedChannel] = remove(outcomes[guarantee.guaranteedChannel], recipient, amount);
+        if (affords(recipient, reprioritizedOutcome, funding) >= amount) {
+            outcomes[guarantee.guaranteedChannel] = reduce(outcomes[guarantee.guaranteedChannel], recipient, amount);
             holdings[guarantor] = holdings[guarantor].sub(amount);
             holdings[recipient] =  holdings[recipient].add(amount);
         } else {
@@ -155,7 +155,7 @@ contract NitroAdjudicator {
         );
     }
 
-    function overlap(address recipient, Outcome memory outcome, uint funding) internal pure returns (uint256) {
+    function affords(address recipient, Outcome memory outcome, uint funding) internal pure returns (uint256) {
         uint result = 0;
 
         for (uint i = 0; i < outcome.destination.length; i++) {
@@ -179,7 +179,7 @@ contract NitroAdjudicator {
         return result;
     }
 
-    function remove(Outcome memory outcome, address recipient, uint amount) internal pure returns (Outcome memory) { 
+    function reduce(Outcome memory outcome, address recipient, uint amount) internal pure returns (Outcome memory) { 
         uint256[] memory updatedAllocation = outcome.allocation;
         uint256 reduction = 0;
         for (uint i = 0; i < outcome.destination.length; i++) {

--- a/packages/fmg-nitro-adjudicator/contracts/NitroAdjudicator.sol
+++ b/packages/fmg-nitro-adjudicator/contracts/NitroAdjudicator.sol
@@ -90,19 +90,15 @@ contract NitroAdjudicator {
             "Transfer: outcome must be present"
         );
 
-        uint owedToDestination = overlap(destination, outcomes[channel], amount);
+        uint channelAffordsForDestination = overlap(destination, outcomes[channel], holdings[channel]);
 
         require(
-            owedToDestination <= holdings[channel],
-            "Transfer: holdings[channel] must cover transfer"
-        );
-        require(
-            owedToDestination >= amount,
-            "Transfer: transfer too large"
+            amount <= channelAffordsForDestination,
+            "Transfer: channel cannot afford the requested transfer amount"
         );
 
-        holdings[destination] = holdings[destination].add(amount);
-        holdings[channel] = holdings[channel].sub(amount);
+        holdings[destination] = holdings[destination] + amount;
+        holdings[channel] = holdings[channel] - amount;
 
         outcomes[channel] = remove(outcomes[channel], destination, amount);
     }

--- a/packages/fmg-nitro-adjudicator/contracts/test-contracts/TestNitroAdjudicator.sol
+++ b/packages/fmg-nitro-adjudicator/contracts/test-contracts/TestNitroAdjudicator.sol
@@ -11,12 +11,12 @@ contract TestNitroAdjudicator is NitroAdjudicator {
         return reprioritize(allocation, guarantee);
     }
 
-    function overlapPub(address recipient, Outcome memory allocation, uint funding) public pure returns (uint256) {
-        return overlap(recipient, allocation, funding);
+    function affordsPub(address recipient, Outcome memory allocation, uint funding) public pure returns (uint256) {
+        return affords(recipient, allocation, funding);
     }
 
-    function removePub(Outcome memory allocation, address recipient, uint amount) public pure returns (Outcome memory) { 
-        return remove(allocation, recipient, amount);
+    function reducePub(Outcome memory allocation, address recipient, uint amount) public pure returns (Outcome memory) { 
+        return reduce(allocation, recipient, amount);
     }
 
     // ****************

--- a/packages/fmg-nitro-adjudicator/package.json
+++ b/packages/fmg-nitro-adjudicator/package.json
@@ -14,6 +14,7 @@
   "dependencies": {
     "ethers": "^4.0.26",
     "fmg-core": "^0.5.6",
+    "openzeppelin-solidity": "^2.1.3",
     "web3": "1.0.0-beta.37"
   },
   "devDependencies": {

--- a/packages/fmg-nitro-adjudicator/test/nitro-adjudicator.test.ts
+++ b/packages/fmg-nitro-adjudicator/test/nitro-adjudicator.test.ts
@@ -635,7 +635,7 @@ describe('nitroAdjudicator', () => {
       });
     });
 
-    describe('overlap', () => {
+    describe('affords', () => {
       it('returns funding when funding is less than the amount allocated to the recipient in the outcome', async () => {
         const recipient = alice.address;
         const outcome = {
@@ -646,7 +646,7 @@ describe('nitroAdjudicator', () => {
           guaranteedChannel: ZERO_ADDRESS,
         };
         const funding = ethers.utils.bigNumberify(2);
-        expect(await nitro.overlapPub(recipient, outcome, funding)).toEqual(funding);
+        expect(await nitro.affordsPub(recipient, outcome, funding)).toEqual(funding);
       });
 
       it('returns funding when funding is equal to than the amount allocated to the recipient in the outcome', async () => {
@@ -659,7 +659,7 @@ describe('nitroAdjudicator', () => {
           guaranteedChannel: ZERO_ADDRESS,
         };
         const funding = aBal;
-        expect((await nitro.overlapPub(recipient, outcome, funding)).toHexString()).toEqual(funding);
+        expect((await nitro.affordsPub(recipient, outcome, funding)).toHexString()).toEqual(funding);
       });
 
       it('returns the allocated amount when funding is greater than the amount allocated to the recipient in the outcome', async () => {
@@ -672,7 +672,7 @@ describe('nitroAdjudicator', () => {
           guaranteedChannel: ZERO_ADDRESS,
         };
         const funding = bigNumberify(aBal).add(1).toHexString();
-        expect((await nitro.overlapPub(recipient, outcome, funding)).toHexString()).toEqual(aBal);
+        expect((await nitro.affordsPub(recipient, outcome, funding)).toHexString()).toEqual(aBal);
       });
 
       it('returns zero when recipient is not a participant', async () => {
@@ -686,11 +686,11 @@ describe('nitroAdjudicator', () => {
         };
         const funding = bigNumberify(aBal).add(1).toHexString();
         const zero = ethers.utils.bigNumberify(0);
-        expect(await nitro.overlapPub(recipient, outcome, funding)).toEqual(zero);
+        expect(await nitro.affordsPub(recipient, outcome, funding)).toEqual(zero);
       });
     });
 
-    describe('remove', () => {
+    describe('reduce', () => {
       it('works', async () => {
         const outcome = {
           destination: [alice.address, bob.address],
@@ -699,20 +699,20 @@ describe('nitroAdjudicator', () => {
           challengeCommitment: getEthersObjectForCommitment(commitment0),
           guaranteedChannel: ZERO_ADDRESS,
         };
-        const removeAmount = 2;
-        const expectedBAllocation = bigNumberify(bBal).sub(removeAmount).toHexString();
-        const allocationAfterRemove = [aBal, expectedBAllocation];
+        const reduceAmount = 2;
+        const expectedBAllocation = bigNumberify(bBal).sub(reduceAmount).toHexString();
+        const allocationAfterReduce = [aBal, expectedBAllocation];
 
         const expectedOutcome = {
           destination: [alice.address, bob.address],
-          allocation: allocationAfterRemove,
+          allocation: allocationAfterReduce,
           finalizedAt: ethers.utils.bigNumberify(0),
           challengeCommitment: getEthersObjectForCommitment(commitment0),
         };
 
 
         const recipient = bob.address;
-        const newOutcome = await nitro.removePub(outcome, recipient, removeAmount);
+        const newOutcome = await nitro.reducePub(outcome, recipient, reduceAmount);
 
         expect(getOutcomeFromParameters(newOutcome)).toMatchObject(expectedOutcome);
       });

--- a/packages/fmg-nitro-adjudicator/yarn.lock
+++ b/packages/fmg-nitro-adjudicator/yarn.lock
@@ -5645,7 +5645,7 @@ web3-utils@1.0.0-beta.37:
     underscore "1.8.3"
     utf8 "2.1.1"
 
-web3@^1.0.0-beta.37:
+web3@1.0.0-beta.37:
   version "1.0.0-beta.37"
   resolved "https://registry.yarnpkg.com/web3/-/web3-1.0.0-beta.37.tgz#b42c30e67195f816cd19d048fda872f70eca7083"
   integrity sha512-8XLgUspdzicC/xHG82TLrcF/Fxzj2XYNJ1KTYnepOI77bj5rvpsxxwHYBWQ6/JOjk0HkZqoBfnXWgcIHCDhZhQ==


### PR DESCRIPTION
- rename `overlap` to `affords`,  `remove` to `reduce`
- use `SafeMath` when performing calculations
- Fix `underflow` bug in `affords`
- Fix `transfer` logic