### PR TITLE
Conditional deposits

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"scripts": {
 		"lerna:bootstrap": "./node_modules/lerna/cli.js bootstrap",
 		"lerna:test": "./node_modules/lerna/bin/lerna.js run test --stream",
-		"test": "run-s test:fmg-core build:fmg-core test:fmg-simple-adjudicator test:fmg-nitro-adjudicator",
+		"test": "run-s test:fmg-core build:fmg-core test:fmg-nitro-adjudicator test:fmg-simple-adjudicator",
 		"test:fmg-core": "(cd packages/fmg-core && npm run test:ci)",
 		"build:fmg-core": "(cd packages/fmg-core && npm run build)",
 		"test:fmg-simple-adjudicator": "(cd packages/fmg-simple-adjudicator && npm run test:ci)",

--- a/packages/fmg-core/yarn.lock
+++ b/packages/fmg-core/yarn.lock
@@ -5632,7 +5632,7 @@ web3-shh@1.0.0-beta.37:
     web3-core-subscriptions "1.0.0-beta.37"
     web3-net "1.0.0-beta.37"
 
-web3-utils@1.0.0-beta.37, web3-utils@^1.0.0-beta.36:
+web3-utils@1.0.0-beta.37:
   version "1.0.0-beta.37"
   resolved "https://registry.yarnpkg.com/web3-utils/-/web3-utils-1.0.0-beta.37.tgz#ab868a90fe5e649337e38bdaf72133fcbf4d414d"
   integrity sha512-kA1fyhO8nKgU21wi30oJQ/ssvu+9srMdjOTKbHYbQe4ATPcr5YNwwrxG3Bcpbu1bEwRUVKHCkqi+wTvcAWBdlQ==
@@ -5645,7 +5645,7 @@ web3-utils@1.0.0-beta.37, web3-utils@^1.0.0-beta.36:
     underscore "1.8.3"
     utf8 "2.1.1"
 
-web3@^1.0.0-beta.36:
+web3@1.0.0-beta.37:
   version "1.0.0-beta.37"
   resolved "https://registry.yarnpkg.com/web3/-/web3-1.0.0-beta.37.tgz#b42c30e67195f816cd19d048fda872f70eca7083"
   integrity sha512-8XLgUspdzicC/xHG82TLrcF/Fxzj2XYNJ1KTYnepOI77bj5rvpsxxwHYBWQ6/JOjk0HkZqoBfnXWgcIHCDhZhQ==

--- a/packages/fmg-nitro-adjudicator/contracts/NitroAdjudicator.sol
+++ b/packages/fmg-nitro-adjudicator/contracts/NitroAdjudicator.sol
@@ -58,10 +58,18 @@ contract NitroAdjudicator {
         uint amount = msg.value;
         uint amountDeposited;
 
+        // This protects against a directly funded channel being defunded due to chain re-orgs,
+        // and allow a wallet implementation to ensure the safety of deposits.
         require(
             holdings[destination] >= expectedHeld,
             "Deposit: holdings[destination] is less than expected"
         );
+
+
+        // If I expect there to be 10 eth and deposit 2, my goal was to get the
+        // balance to 12 eth.
+        // In case some arbitrary person deposited 1 eth before I noticed, making the
+        // holdings 11 eth, I should be refunded 1 eth.
         if (holdings[destination] == expectedHeld) {
             amountDeposited = amount;
         } else if (holdings[destination] < expectedHeld.add(amount)) {

--- a/packages/fmg-nitro-adjudicator/package.json
+++ b/packages/fmg-nitro-adjudicator/package.json
@@ -24,7 +24,7 @@
     "dotenv": "^6.1.0",
     "ganache-cli": "6.1.8",
     "jest": "^23.6.0",
-    "magmo-devtools": "git+https://github.com/magmo/devtools.git#v0.1.13",
+    "magmo-devtools": "git+https://github.com/magmo/devtools.git#v0.1.14",
     "truffle": "^5.0.0-beta.2",
     "ts-jest": "^23.10.5",
     "tslint": "^5.11.0",

--- a/packages/fmg-nitro-adjudicator/package.json
+++ b/packages/fmg-nitro-adjudicator/package.json
@@ -24,7 +24,7 @@
     "dotenv": "^6.1.0",
     "ganache-cli": "6.1.8",
     "jest": "^23.6.0",
-    "magmo-devtools": "git+https://github.com/magmo/devtools.git#v0.1.11",
+    "magmo-devtools": "git+https://github.com/magmo/devtools.git#v0.1.13",
     "truffle": "^5.0.0-beta.2",
     "ts-jest": "^23.10.5",
     "tslint": "^5.11.0",

--- a/packages/fmg-nitro-adjudicator/test/nitro-adjudicator.test.ts
+++ b/packages/fmg-nitro-adjudicator/test/nitro-adjudicator.test.ts
@@ -193,22 +193,13 @@ describe('nitroAdjudicator', () => {
       turnNum: 8,
       appCounter: new BigNumber(3).toHexString(),
     });
-
-    const { r: r0, s: s0, v: v0 } = sign(getHexForCommitment(commitment4), alice.privateKey);
-    const { r: r1, s: s1, v: v1 } = sign(getHexForCommitment(commitment5), bob.privateKey);
-
-    conclusionProof = {
-      penultimateCommitment: getEthersObjectForCommitment(commitment4),
-      ultimateCommitment: getEthersObjectForCommitment(commitment5),
-      penultimateSignature: { v: v0, r: r0, s: s0 },
-      ultimateSignature: { v: v1, r: r1, s: s1 },
-    };
   });
 
   let expectedAssertions;
 
   beforeEach(() => {
     expectedAssertions = 1;
+    channel.nonce += 1;
   });
 
   describe('Eth management', () => {
@@ -839,6 +830,16 @@ describe('nitroAdjudicator', () => {
     });
 
     describe('concludeAndWithdraw', () => {
+      beforeEach(() => {
+        const { r: r0, s: s0, v: v0 } = sign(getHexForCommitment(commitment4), alice.privateKey);
+        const { r: r1, s: s1, v: v1 } = sign(getHexForCommitment(commitment5), bob.privateKey);
+        conclusionProof = {
+          penultimateCommitment: getEthersObjectForCommitment(commitment4),
+          ultimateCommitment: getEthersObjectForCommitment(commitment5),
+          penultimateSignature: { v: v0, r: r0, s: s0 },
+          ultimateSignature: { v: v1, r: r1, s: s1 },
+        };
+      });
       it('works when the channel is not concluded', async () => {
         const total = bigNumberify(aBal).add(bBal);
         const channelId = getChannelID(channel);
@@ -1123,6 +1124,28 @@ describe('nitroAdjudicator', () => {
         expect(await nitro.isChallengeOngoing(getChannelID(channel))).toBe(true);
       }
 
+      beforeEach(() => {
+        agreedCommitment = commitment0;
+        challengeCommitment = commitment1;
+        refutationCommitment = commitment3;
+
+        const { r: r0, s: s0, v: v0 } = sign(
+          getHexForCommitment(agreedCommitment),
+          challengee.privateKey,
+        );
+        const { r: r1, s: s1, v: v1 } = sign(
+          getHexForCommitment(challengeCommitment),
+          challenger.privateKey,
+        );
+        signatures = [{ r: r0, s: s0, v: v0 }, { r: r1, s: s1, v: v1 }];
+
+        const { r: r2, s: s2, v: v2 } = sign(
+          getHexForCommitment(refutationCommitment),
+          challenger.privateKey,
+        );
+        refutationSignature = { r: r2, s: s2, v: v2 };
+      });
+
       it('works', async () => {
         await runBeforeRefute();
 
@@ -1134,22 +1157,6 @@ describe('nitroAdjudicator', () => {
 
         // "challenge should be cancelled
         expect(await nitro.isChallengeOngoing(getChannelID(channel))).toBe(false);
-      });
-
-      beforeAll(() => {
-        agreedCommitment = commitment0;
-        challengeCommitment = commitment1;
-        refutationCommitment = commitment3;
-
-        const { r: r0, s: s0, v: v0 } = sign(getHexForCommitment(agreedCommitment), challengee.privateKey);
-        const { r: r1, s: s1, v: v1 } = sign(getHexForCommitment(challengeCommitment), challenger.privateKey);
-        signatures = [
-          { r: r0, s: s0, v: v0 },
-          { r: r1, s: s1, v: v1 },
-        ];
-
-        const { r: r2, s: s2, v: v2 } = sign(getHexForCommitment(refutationCommitment), challenger.privateKey);
-        refutationSignature = { r: r2, s: s2, v: v2 };
       });
 
       it('reverts when the channel is closed', async () => {
@@ -1204,19 +1211,25 @@ describe('nitroAdjudicator', () => {
       let signatures;
       let responseSignature;
 
-      beforeAll(() => {
+      beforeEach(() => {
         agreedCommitment = commitment0;
         challengeCommitment = commitment1;
         responseCommitment = commitment2;
 
-        const { r: r0, s: s0, v: v0 } = sign(getHexForCommitment(agreedCommitment), challengee.privateKey);
-        const { r: r1, s: s1, v: v1 } = sign(getHexForCommitment(challengeCommitment), challenger.privateKey);
-        signatures = [
-          { r: r0, s: s0, v: v0 },
-          { r: r1, s: s1, v: v1 },
-        ];
+        const { r: r0, s: s0, v: v0 } = sign(
+          getHexForCommitment(agreedCommitment),
+          challengee.privateKey,
+        );
+        const { r: r1, s: s1, v: v1 } = sign(
+          getHexForCommitment(challengeCommitment),
+          challenger.privateKey,
+        );
+        signatures = [{ r: r0, s: s0, v: v0 }, { r: r1, s: s1, v: v1 }];
 
-        const { r: r2, s: s2, v: v2 } = sign(getHexForCommitment(responseCommitment), challengee.privateKey);
+        const { r: r2, s: s2, v: v2 } = sign(
+          getHexForCommitment(responseCommitment),
+          challengee.privateKey,
+        );
         responseSignature = { r: r2, s: s2, v: v2 };
       });
 
@@ -1305,21 +1318,30 @@ describe('nitroAdjudicator', () => {
       let alternativeSignature;
       let responseSignature;
 
-      beforeAll(() => {
+      beforeEach(() => {
         agreedCommitment = commitment0;
         challengeCommitment = commitment1;
         alternativeCommitment = commitment1alt;
         responseCommitment = commitment2alt;
 
-        const { r: r0, s: s0, v: v0 } = sign(getHexForCommitment(agreedCommitment), challengee.privateKey);
-        const { r: r1, s: s1, v: v1 } = sign(getHexForCommitment(challengeCommitment), challenger.privateKey);
-        signatures = [
-          { r: r0, s: s0, v: v0 },
-          { r: r1, s: s1, v: v1 },
-        ];
+        const { r: r0, s: s0, v: v0 } = sign(
+          getHexForCommitment(agreedCommitment),
+          challengee.privateKey,
+        );
+        const { r: r1, s: s1, v: v1 } = sign(
+          getHexForCommitment(challengeCommitment),
+          challenger.privateKey,
+        );
+        signatures = [{ r: r0, s: s0, v: v0 }, { r: r1, s: s1, v: v1 }];
 
-        const { r: r2, s: s2, v: v2 } = sign(getHexForCommitment(alternativeCommitment), challenger.privateKey);
-        const { r: r3, s: s3, v: v3 } = sign(getHexForCommitment(responseCommitment), challengee.privateKey);
+        const { r: r2, s: s2, v: v2 } = sign(
+          getHexForCommitment(alternativeCommitment),
+          challenger.privateKey,
+        );
+        const { r: r3, s: s3, v: v3 } = sign(
+          getHexForCommitment(responseCommitment),
+          challengee.privateKey,
+        );
 
         alternativeSignature = { r: r2, s: s2, v: v2 };
         responseSignature = { r: r3, s: s3, v: v3 };

--- a/packages/fmg-nitro-adjudicator/truffle.js
+++ b/packages/fmg-nitro-adjudicator/truffle.js
@@ -1,4 +1,4 @@
-require('dotenv').config()
+require('dotenv').config();
 
 module.exports = {
   networks: {
@@ -18,7 +18,7 @@ module.exports = {
   },
   compilers: {
     solc: {
-      version: "0.5.0",
-    }
-  }
+      version: '0.5.2',
+    },
+  },
 };

--- a/packages/fmg-nitro-adjudicator/yarn.lock
+++ b/packages/fmg-nitro-adjudicator/yarn.lock
@@ -3291,9 +3291,9 @@ lru-cache@^4.0.1:
     pseudomap "^1.0.2"
     yallist "^2.1.2"
 
-"magmo-devtools@git+https://github.com/magmo/devtools.git#v0.1.13":
+"magmo-devtools@git+https://github.com/magmo/devtools.git#v0.1.14":
   version "0.1.13"
-  resolved "git+https://github.com/magmo/devtools.git#650f698f2468ae76020e1466b9686939aa018c4e"
+  resolved "git+https://github.com/magmo/devtools.git#8fece104b7b4b7ead39fb9b5d03c661f7b094f90"
   dependencies:
     chai "^4.2.0"
     detect-port "^1.3.0"

--- a/packages/fmg-nitro-adjudicator/yarn.lock
+++ b/packages/fmg-nitro-adjudicator/yarn.lock
@@ -895,6 +895,11 @@ combined-stream@^1.0.6, combined-stream@~1.0.6:
   dependencies:
     delayed-stream "~1.0.0"
 
+command-exists@^1.2.8:
+  version "1.2.8"
+  resolved "https://registry.yarnpkg.com/command-exists/-/command-exists-1.2.8.tgz#715acefdd1223b9c9b37110a149c6392c2852291"
+  integrity sha512-PM54PkseWbiiD/mMsbvW351/u+dafwTJ0ye2qB60G1aGQP9j3xK2gmMDc+R34L3nDtx4qMCitXT75mkbkGJDLw==
+
 commander@2.11.0:
   version "2.11.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.11.0.tgz#157152fd1e7a6c8d98a5b715cf376df928004563"
@@ -3286,14 +3291,15 @@ lru-cache@^4.0.1:
     pseudomap "^1.0.2"
     yallist "^2.1.2"
 
-"magmo-devtools@git+https://github.com/magmo/devtools.git#v0.1.11":
-  version "0.1.11"
-  resolved "git+https://github.com/magmo/devtools.git#ff7e4b18122c465c64c478d8561d7f4f47d4932e"
+"magmo-devtools@git+https://github.com/magmo/devtools.git#v0.1.13":
+  version "0.1.13"
+  resolved "git+https://github.com/magmo/devtools.git#650f698f2468ae76020e1466b9686939aa018c4e"
   dependencies:
     chai "^4.2.0"
     detect-port "^1.3.0"
     dotenv "^6.1.0"
     ethers "^4.0.15"
+    solc "^0.5.4"
     yargs "^12.0.5"
 
 make-dir@^1.0.0:
@@ -3830,6 +3836,11 @@ once@^1.3.0, once@^1.3.1, once@^1.4.0:
   dependencies:
     wrappy "1"
 
+openzeppelin-solidity@^2.1.3:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/openzeppelin-solidity/-/openzeppelin-solidity-2.2.0.tgz#1f0e857f53bda29b77a8e72f9a629db81015fd34"
+  integrity sha512-HfQq0xyT+EPs/lTWEd5Odu4T7CYdYe+qwf54EH28FQZthp4Bs6IWvOlOumTdS2dvpwZoTXURAopHn2LN1pwAGQ==
+
 optimist@^0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/optimist/-/optimist-0.6.1.tgz#da3ea74686fa21a19a111c326e90eb15a0196686"
@@ -3878,7 +3889,7 @@ os-locale@^3.0.0:
     lcid "^2.0.0"
     mem "^4.0.0"
 
-os-tmpdir@^1.0.0, os-tmpdir@^1.0.1:
+os-tmpdir@^1.0.0, os-tmpdir@^1.0.1, os-tmpdir@~1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/os-tmpdir/-/os-tmpdir-1.0.2.tgz#bbe67406c79aa85c5cfec766fe5734555dfa1274"
   integrity sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=
@@ -4748,6 +4759,20 @@ solc@^0.5.0:
     semver "^5.5.0"
     yargs "^11.0.0"
 
+solc@^0.5.4:
+  version "0.5.7"
+  resolved "https://registry.yarnpkg.com/solc/-/solc-0.5.7.tgz#d84697ac5cc63d9b2139bfb349cec64b64861cdc"
+  integrity sha512-DaYFzB3AAYjzPtgUl9LenPY2xjI3wG9k8U8T8YE/sXHVIoCirCY5MB6mhcFPgk/VyUtaWZPUCWiYS1E6RSiiqw==
+  dependencies:
+    command-exists "^1.2.8"
+    fs-extra "^0.30.0"
+    keccak "^1.0.2"
+    memorystream "^0.3.1"
+    require-from-string "^2.0.0"
+    semver "^5.5.0"
+    tmp "0.0.33"
+    yargs "^11.0.0"
+
 source-map-resolve@^0.5.0:
   version "0.5.2"
   resolved "https://registry.yarnpkg.com/source-map-resolve/-/source-map-resolve-0.5.2.tgz#72e2cc34095543e43b2c62b2c4c10d4a9054f259"
@@ -5092,6 +5117,13 @@ timed-out@^4.0.0, timed-out@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/timed-out/-/timed-out-4.0.1.tgz#f32eacac5a175bea25d7fab565ab3ed8741ef56f"
   integrity sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8=
+
+tmp@0.0.33:
+  version "0.0.33"
+  resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.0.33.tgz#6d34335889768d21b2bcda0aa277ced3b1bfadf9"
+  integrity sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==
+  dependencies:
+    os-tmpdir "~1.0.2"
 
 tmpl@1.0.x:
   version "1.0.4"


### PR DESCRIPTION
- The `deposit` function accepts an `expectedHeld` integer.
- It reverts if `holdings[destination]` is not at least what was expected. This allows a wallet to ensure the safety of their user's deposit by ensuring that the channel affords their deposit.
- It refunds any extra deposit past what the caller expected to deposit.